### PR TITLE
[WIP] Building with MSVC19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+javacall/configuration/phoneMEFeature/*/output
+pcsl/output
+cldc/build/win32_i386_ide
+cldc/build/*/dist
+cldc/build/*/loopgen
+cldc/build/*/romgen
+cldc/build/*/target
+cldc/build/*/tools
+cldc/build/classes
+cldc/build/tmpclasses
+cldc/build/classes.zip
+midp/build/*/output
+tools/output
+*.pdb

--- a/cldc/build/share/jvm.make
+++ b/cldc/build/share/jvm.make
@@ -49,7 +49,8 @@ NATIVES_TABLE        = $(GEN_DIR)/NativesTable.cpp
 BUILDTOOLS_DIR       = $(BuildSpace)/$(BUILD_DIR_NAME)/tools
 BUILDTOOL_JAR        = $(BUILDTOOLS_DIR)/buildtool.jar
 ifeq ($(USE_VS2005), true)
-VC_MANIFEST_EMBED_EXE = mt.exe -nologo -manifest $@.manifest "-outputresource:$@"
+VC_MANIFEST_EMBED_EXE = true
+#VC_MANIFEST_EMBED_EXE = mt.exe -nologo -manifest $@.manifest "-outputresource:$@"
 else
 VC_MANIFEST_EMBED_EXE = true
 endif
@@ -847,7 +848,7 @@ ifeq ($(USE_VS2005), true)
 CPP_DEF_FLAGS          += -D_CRT_SECURE_NO_DEPRECATE
 endif
 
-CPP_DEF_FLAGS          += -DWIN32 -D_WINDOWS
+CPP_DEF_FLAGS          += -DWIN32 -D_WINDOWS /Zc:preprocessor
 CPP_DEF_FLAGS          += $(CPP_DEF_FLAGS_$(BUILD))
 CPP_DEF_FLAGS          += /W3 /nologo  \
                           $(SAVE_TEMPS_CFLAGS) \
@@ -974,7 +975,7 @@ else
 $(LOOP_GENERATOR): $(BUILD_PCH) $(Obj_Files) \
 		   InterpreterSkeleton.obj OopMapsSkeleton.obj
 	$(A)$(LINK) $(PCSL_LIBS) $(LINK_FLAGS) /out:$@ $(Obj_Files) \
-		   InterpreterSkeleton.obj OopMapsSkeleton.obj
+		   InterpreterSkeleton.obj OopMapsSkeleton.obj $(BUILD_PCH)
 	$(A)$(VC_MANIFEST_EMBED_EXE)
 	$(A)echo generated `pwd`/$@
 endif
@@ -999,30 +1000,30 @@ endif
 $(ROM_GENERATOR): $(CLDC_ZIP) $(Obj_Files) OopMapsSkeleton.obj $(GP_TABLE_OBJ)
 	$(A)echo "linking ROM generator: $(ROM_GENERATOR)"
 	$(A)$(LINK) $(PCSL_LIBS) $(LINK_FLAGS) /out:$@ \
-		$(Obj_Files) OopMapsSkeleton.obj $(GP_TABLE_OBJ)
+		$(Obj_Files) OopMapsSkeleton.obj $(GP_TABLE_OBJ) $(BUILD_PCH)
 	$(A)$(ROM_GENERATOR) +GenerateOopMaps
 	$(A)$(MAKE) OopMaps.obj
 	$(A)echo "re-linking ROM generator: $(ROM_GENERATOR)"
 	$(A)$(LINK) $(PCSL_LIBS) $(LINK_FLAGS) /out:$@ $(Obj_Files) \
-                OopMaps.obj \
+                OopMaps.obj $(BUILD_PCH)\
                 $(GP_TABLE_OBJ)
 	$(A)echo generated `pwd`/$@
 else
 $(ROM_GENERATOR): $(BUILD_PCH) $(Obj_Files) InterpreterSkeleton.obj \
                                             OopMapsSkeleton.obj
 	$(A)$(LINK) $(PCSL_LIBS) $(LINK_FLAGS) /out:$@ $(Obj_Files) \
-		InterpreterSkeleton.obj OopMapsSkeleton.obj
+		InterpreterSkeleton.obj OopMapsSkeleton.obj $(BUILD_PCH)
 	$(A)$(ROM_GENERATOR) $(LOOP_GEN_ARG)
 	$(A)$(ROM_GENERATOR) +GenerateOopMaps
 	$(A)$(MAKE) Interpreter_$(arch).obj
 	$(A)$(MAKE) OopMaps.obj
 	$(A)$(LINK) $(PCSL_LIBS) $(LINK_FLAGS) /out:$@ \
-		$(Obj_Files) Interpreter_$(arch).obj OopMaps.obj
+		$(Obj_Files) Interpreter_$(arch).obj OopMaps.obj $(BUILD_PCH)
 	$(A)$(VC_MANIFEST_EMBED_EXE)
 	$(A)echo generated `pwd`/$@
 
 endif
-endif
+endif # IsRomGen
 
 MAKE_EXPORT_LINK_OUT_SWITCH1     =
 MAKE_EXPORT_LINK_OUT_SWITCH2     = /out:
@@ -1038,7 +1039,7 @@ $(DIST_LIB_DIR)/$(JVM_LOG_NAME)::
 #     - LIBX_OBJS: the ones that are exported privately in $(JVMX_LIB)
 #     - LIBTEST_OBJS: the ones that are exported privately in $(JVMTEST_LIB)
 #     - EXE_OBJS:  the ones that are used only by $(JVM_EXE)
-LIB_OBJS := $(Obj_Files) OopMaps.obj
+LIB_OBJS := $(Obj_Files) OopMaps.obj $(BUILD_PCH)
 LIB_OBJS := $(subst BSDSocket.obj,,$(LIB_OBJS))
 LIBX_OBJS +=        BSDSocket.obj
 LIB_OBJS := $(subst ReflectNatives.obj,,$(LIB_OBJS))

--- a/cldc/src/vm/share/runtime/JVM.cpp
+++ b/cldc/src/vm/share/runtime/JVM.cpp
@@ -1406,7 +1406,7 @@ void JVM::P_CR(bool cond) {
 }
 
 void JVM::print_hrticks(const char *name, julong hrticks) {
- tty->print_cr("%-25s = "JVM_LLD" hrticks or %.2lf msec",
+ tty->print_cr("%-25s = " JVM_LLD " hrticks or %.2lf msec",
             name, hrticks,  msec_scale(hrticks));
 }
 #endif  // ENABLE_PERFORMANCE_COUNTERS

--- a/cldc/src/vm/share/utilities/GlobalDefinitions_visCPP.hpp
+++ b/cldc/src/vm/share/utilities/GlobalDefinitions_visCPP.hpp
@@ -92,9 +92,12 @@ const jlong max_jlong = 0x7fffffffffffffffL;
 //----------------------------------------------------------------------------
 // Miscellaneous
 
+#if _MSC_VER < 1900
 inline int vsnprintf(char* buf, size_t count, const char* fmt, va_list argptr) {
   return _vsnprintf(buf, count, fmt, argptr);
 }
+#endif
+
 
 //----------------------------------------------------------------------------
 // Macros about compiler-specific behavior.

--- a/javacall/implementation/win32/midp/res/emulator.rc
+++ b/javacall/implementation/win32/midp/res/emulator.rc
@@ -30,7 +30,9 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+//#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -96,7 +98,7 @@ BEGIN
             VALUE "FileDescription", "runMidlet"
             VALUE "FileVersion", "9, 9, 9, 9"
             VALUE "InternalName", "runMidlet"
-            VALUE "LegalCopyright", "Copyright © 2007"
+            VALUE "LegalCopyright", "Copyright ï¿½ 2007"
             VALUE "OriginalFilename", "runMidlet.exe"
             VALUE "ProductName", " phoneME Feature "
             VALUE "ProductVersion", "0, 2, 0, 0"

--- a/midp/src/ams/example/jams/runMidlet.gmk
+++ b/midp/src/ams/example/jams/runMidlet.gmk
@@ -39,7 +39,8 @@
 #
 
 ifeq ($(USE_VS2005), true)
-VC_MANIFEST_EMBED_EXE = mt.exe -nologo -manifest `$(call fixcygpath,$@.manifest)` "-outputresource:`$(call fixcygpath,$@)`"
+#VC_MANIFEST_EMBED_EXE = mt.exe -nologo -manifest `$(call fixcygpath,$@.manifest)` "-outputresource:`$(call fixcygpath,$@)`"
+VC_MANIFEST_EMBED_EXE = true
 else
 VC_MANIFEST_EMBED_EXE = true
 endif


### PR DESCRIPTION
To compile with Visual Studio 2022 (MSVC19), I modified some configurations.

## Requirements

- MSVC 19
- cygwin
- Java SE 1.4.2_19

## Building 

1. Clone source code onto `C:\pspkvm`
2. Calling `msvars32.bat` and launch `bash(cygwin)` .
3. Mount `C:\pspkvm` on `/pspkvm` .
4. `cd /pspkvm`
5. USE_VS2005=true ./build-win32-cldc.sh -C -J C:/j2sdk1.4.2_19

## Note

- `link.exe` in Visual Studio is incompatible with `/usr/bin/link` in cygwin. To avoid using `/usr/bin/link`, you should rename link.exe in cygwin to other name (like `link_cygwin.exe` )

closes #1